### PR TITLE
Update main in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nuxt-gettext",
   "version": "0.1.6",
   "description": "Translation module utilizing the gettext ecosystem",
-  "main": "lib/module.js",
+  "main": "src/index.js",
   "scripts": {
     "dev": "nuxt test/fixture",
     "lint": "eslint --fix lib test",


### PR DESCRIPTION
Update the `main` field in `package.json` to reflect the file tree. This fixes the issue of nuxt not finding the package